### PR TITLE
Stop forcing port during requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "stack",
         "orm"
     ],
-    "version": "1.0.11",
+    "version": "1.0.12",
     "main": "lib/index.js",
     "types": "index.d.ts",
     "license": "MIT",

--- a/test/DataProvider/Middleware/AuthMiddleware.js
+++ b/test/DataProvider/Middleware/AuthMiddleware.js
@@ -1,3 +1,4 @@
+const { Http } = require('./../../../lib');
 
 
 class AuthMiddleware
@@ -5,6 +6,9 @@ class AuthMiddleware
 
     do(request)
     {
+        if (request.getBody().crash)
+            throw new Http.Exception.BadRequestError('Error');
+
         if (request.getUrl() === '/auth/route')
             return request.getUrl();
     }

--- a/test/Functional/App.test.js
+++ b/test/Functional/App.test.js
@@ -213,10 +213,17 @@ describe('AppTest', function()
             new Http.MakeRequest()
                 .setPort(3000)
                 .get('/auth/route')
-                .then((httpResponse) => {
-                    expect(httpResponse.getContent()).to.be.equal('/auth/route');
-                })
+                .then((httpResponse) => expect(httpResponse.getContent()).to.be.equal('/auth/route'))
                 .then(() => done());
+        });
+
+        it('Should present problem from middleware and make a response', done => 
+        {
+            new Http.MakeRequest()
+                .setPort(3000)
+                .post('/auth/route', {}, { 'crash': true })
+                .then((httpResponse) => expect(httpResponse.getContent()).to.be.equal('Error'))
+                .then(() => done());   
         });
     });
 

--- a/test/Unit/Http/MakeRequest.test.js
+++ b/test/Unit/Http/MakeRequest.test.js
@@ -7,7 +7,6 @@ describe('MakeRequestTest', () =>
     it('Should present error making request', done => 
     {
         new Http.MakeRequest()
-            .setPort(3000)
             .get('/xxx')
             .catch((err) => expect(err).to.be.instanceOf(Error)).then(() => done());
     });
@@ -15,7 +14,6 @@ describe('MakeRequestTest', () =>
     it('Should present error making request from another flux', done => 
     {
         new Http.MakeRequest()
-            .setPort(3000)
             .post('/xxx')
             .catch((err) => expect(err).to.be.instanceOf(Error)).then(() => done());
     });

--- a/ts/lib/Http.ts
+++ b/ts/lib/Http.ts
@@ -156,7 +156,7 @@ export namespace Http
         
         public getBody():any
         {
-            return this.request.body || {};
+            return this.request.body;
         }
 
         public getCompleteUrl():string

--- a/ts/lib/Http.ts
+++ b/ts/lib/Http.ts
@@ -107,11 +107,15 @@ export namespace Http
             });
         }
 
-        private treatUrl(url, params:any={}):string
+        private treatUrl(url:string, params:any={}):string
         {
-            url = `${this.host}:${this.port}${url}`;
-            if (url.substr(0, 7) !== 'http://' && url.substr(0, 7) !== 'https:/')
-                url = `http://${url}`
+            let uri:string = `${this.host}`;
+            if (this.port !== 80)
+                uri += `:${this.port}`;
+
+            uri += url;
+            if (uri.substr(0, 7) !== 'http://' && uri.substr(0, 7) !== 'https:/')
+                uri = `http://${uri}`
             
             params = Object.keys(params)
                 .map((key:string) => {
@@ -123,9 +127,9 @@ export namespace Http
                 .join('&');
                 
             if (params.length > 0)
-                url += `?${params}`;
+                uri += `?${params}`;
             
-            return url;
+            return uri;
         }
 
     }


### PR DESCRIPTION
Was having problems with https requests because port was forced in URL.
So, I removed ports forcing and it is included in URL only when different of 80.